### PR TITLE
Add support for basePath variable

### DIFF
--- a/lib/standalone/server-handler.ts
+++ b/lib/standalone/server-handler.ts
@@ -37,7 +37,6 @@ const server = slsHttp(
 	{
 		// We have separate function for handling images. Assets are handled by S3.
 		binary: false,
-		// @ts-ignore
 		basePath: process.env.NEXTJS_LAMBDA_BASE_PATH
 	},
 )

--- a/lib/standalone/server-handler.ts
+++ b/lib/standalone/server-handler.ts
@@ -37,6 +37,8 @@ const server = slsHttp(
 	{
 		// We have separate function for handling images. Assets are handled by S3.
 		binary: false,
+		// @ts-ignore
+		basePath: process.env.NEXTJS_LAMBDA_BASE_PATH
 	},
 )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "constructs": "^10",
         "next": "^12.3.0",
         "replace-in-file": "^6.3.5",
-        "serverless-http": "^3.0.2",
+        "serverless-http": "^3.0.3",
         "simple-git": "^3.14.1"
       },
       "bin": {
@@ -3249,9 +3249,9 @@
       }
     },
     "node_modules/serverless-http": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.0.2.tgz",
-      "integrity": "sha512-0r4TEhb8umOmbzvn9y9aFjdWdrapyNhTHd2oz1YsCRn+9A5RV3DOj6Pl3DH8BQgHnAlG6g88hiBB6/zefnvPRg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.0.3.tgz",
+      "integrity": "sha512-op91LTe8s8ZtRckjrXxvnAxkoHQv+drk1bZr3inN3kunIP5QHuJIevHrvyDjVoL7yK9oOI1Vf/57radEcLVMjw==",
       "engines": {
         "node": ">=12.0"
       }
@@ -5761,9 +5761,9 @@
       }
     },
     "serverless-http": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.0.2.tgz",
-      "integrity": "sha512-0r4TEhb8umOmbzvn9y9aFjdWdrapyNhTHd2oz1YsCRn+9A5RV3DOj6Pl3DH8BQgHnAlG6g88hiBB6/zefnvPRg=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.0.3.tgz",
+      "integrity": "sha512-op91LTe8s8ZtRckjrXxvnAxkoHQv+drk1bZr3inN3kunIP5QHuJIevHrvyDjVoL7yK9oOI1Vf/57radEcLVMjw=="
     },
     "simple-git": {
       "version": "3.14.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "constructs": "^10",
     "next": "^12.3.0",
     "replace-in-file": "^6.3.5",
-    "serverless-http": "^3.0.2",
+    "serverless-http": "^3.0.3",
     "simple-git": "^3.14.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix #43 

See #43 for detailed discussion of issue.

This PR allows users to specify an optional `basePath` which will be removed from request paths before the requests are passed to Nextjs within the `server-handler` lambda. This will allow for the `server-handler` lambda to be served on the same APIG as other lambdas without conflict, where each has a path prefix, e.g. `/server` and `/image`.

There is a [PR](https://github.com/dougmoscrop/serverless-http/pull/246) of mine that been merged into `serverless-http` has not yet been released, which adds the `basePath` property into the Options Typescript type definition. Until that occurs, the `rollup` command fails because it performs Typescript checking. To avoid this failure, this PR adds a temporary `@ts-ignore` to ignore this issue.  This line can be removed when the next version of `serverless-http` is released with my PR in it.
