### PR TITLE
#56 Allow an API route to return binary data 

### DIFF
--- a/lib/standalone/server-handler.ts
+++ b/lib/standalone/server-handler.ts
@@ -36,7 +36,10 @@ const server = slsHttp(
 	},
 	{
 		// We have separate function for handling images. Assets are handled by S3.
-		binary: false,
+		// If you wish to return binary data from an API route then set process.env.BINARY_CONTENT_TYPES to be a
+		// comma-separated list of Content-Types to be treated as binary data.
+		// c.f. https://github.com/dougmoscrop/serverless-http/blob/master/lib/provider/aws/is-binary.js for details on
+		// how this works.
 		provider: 'aws',
 		basePath: process.env.NEXTJS_LAMBDA_BASE_PATH,
 	},

--- a/lib/standalone/server-handler.ts
+++ b/lib/standalone/server-handler.ts
@@ -36,10 +36,7 @@ const server = slsHttp(
 	},
 	{
 		// We have separate function for handling images. Assets are handled by S3.
-		// If you wish to return binary data from an API route then set process.env.BINARY_CONTENT_TYPES to be a
-		// comma-separated list of Content-Types to be treated as binary data.
-		// c.f. https://github.com/dougmoscrop/serverless-http/blob/master/lib/provider/aws/is-binary.js for details on
-		// how this works.
+                binary: true,
 		provider: 'aws',
 		basePath: process.env.NEXTJS_LAMBDA_BASE_PATH,
 	},


### PR DESCRIPTION
Does not hard-code the response of the server lambda as being non-binary. See #56 for discussion.