### PR TITLE
fix: eslint config and errors

### DIFF
--- a/lib/cdk/utils/cfnCertificate.ts
+++ b/lib/cdk/utils/cfnCertificate.ts
@@ -1,5 +1,6 @@
 import { CfnOutput, Stack } from 'aws-cdk-lib'
 import { CertificateValidation, DnsValidatedCertificate } from 'aws-cdk-lib/aws-certificatemanager'
+
 import { MappedDomain } from '../types'
 
 export interface SetupCfnCertificateProps {

--- a/lib/cdk/utils/cfnCertificate.ts
+++ b/lib/cdk/utils/cfnCertificate.ts
@@ -14,8 +14,6 @@ export const setupCfnCertificate = (scope: Stack, { domains }: SetupCfnCertifica
 	// https://github.com/aws/aws-cdk/issues/8934
 	const multiZoneMap = otherDomains.reduce((acc, curr) => ({ ...acc, [curr.domain]: curr.zone }), {})
 
-	const easyCheck = domains.reduce((acc, curr) => ({ ...acc, [curr.domain]: curr.zone.zoneName }), {})
-
 	// We need to stick with DNSValidatedCertificate for now, because Certificate construct does not support region specifiation.
 	// So we would need to manage two different stacks and create certificate in us-east-1 with second stack.
 	const certificate = new DnsValidatedCertificate(scope, 'Certificate', {

--- a/lib/cdk/utils/cfnDistro.ts
+++ b/lib/cdk/utils/cfnDistro.ts
@@ -14,6 +14,7 @@ import {
 } from 'aws-cdk-lib/aws-cloudfront'
 import { HttpOrigin, S3Origin } from 'aws-cdk-lib/aws-cloudfront-origins'
 import { Bucket } from 'aws-cdk-lib/aws-s3'
+
 import { MappedDomain } from '../types'
 
 export interface SetupCfnDistroProps {

--- a/lib/cdk/utils/dnsRecords.ts
+++ b/lib/cdk/utils/dnsRecords.ts
@@ -3,10 +3,11 @@ import { IDistribution } from 'aws-cdk-lib/aws-cloudfront'
 import { AaaaRecord, ARecord, HostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53'
 import { CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets'
 import { execSync } from 'child_process'
-import { MappedDomain } from '../types'
 import { readFileSync } from 'fs'
 import { tmpdir } from 'os'
 import path from 'path'
+
+import { MappedDomain } from '../types'
 
 export interface PrepareDomainProps {
 	domains: string[]

--- a/lib/cdk/utils/redirect.ts
+++ b/lib/cdk/utils/redirect.ts
@@ -1,5 +1,6 @@
 import { CfnOutput, Stack } from 'aws-cdk-lib'
 import { HttpsRedirect } from 'aws-cdk-lib/aws-route53-patterns'
+
 import { MappedDomain } from '../types'
 
 export interface SetupApexRedirectProps {

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -2,12 +2,13 @@
 
 import { Command } from 'commander'
 import path from 'path'
+
 import packageJson from '../package.json'
+import { DEFAULT_MEMORY as IMAGE_LAMBDA_DEFAULT_MEMORY, DEFAULT_TIMEOUT as IMAGE_LAMBDA_DEFAULT_TIMEOUT } from './cdk/utils/imageLambda'
 import { deployHandler } from './cli/deploy'
 import { packHandler } from './cli/pack'
-import { wrapProcess } from './utils'
-import { DEFAULT_TIMEOUT as IMAGE_LAMBDA_DEFAULT_TIMEOUT, DEFAULT_MEMORY as IMAGE_LAMBDA_DEFAULT_MEMORY } from './cdk/utils/imageLambda'
 import { removeHandler } from './cli/remove'
+import { wrapProcess } from './utils'
 
 const commandCwd = process.cwd()
 const program = new Command()

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,15 +1,14 @@
-export { handler as serverHandler } from './server-handler'
+import { setupApiGateway, SetupApiGwProps } from './cdk/utils/apiGw'
+import { setupCfnCertificate, SetupCfnCertificateProps } from './cdk/utils/cfnCertificate'
+import { setupCfnDistro, SetupCfnDistroProps } from './cdk/utils/cfnDistro'
+import { PrepareDomainProps, prepareDomains, setupDnsRecords, SetupDnsRecordsProps } from './cdk/utils/dnsRecords'
+import { setupImageLambda, SetupImageLambdaProps } from './cdk/utils/imageLambda'
+import { setupAssetsBucket, UploadAssetsProps, uploadStaticAssets } from './cdk/utils/s3'
+import { setupServerLambda, SetupServerLambdaProps } from './cdk/utils/serverLambda'
 
 export { NextStandaloneStack } from './cdk/stack'
 export { CustomStackProps } from './cdk/types'
-
-import { SetupApiGwProps, setupApiGateway } from './cdk/utils/apiGw'
-import { setupCfnCertificate, SetupCfnCertificateProps } from './cdk/utils/cfnCertificate'
-import { SetupCfnDistroProps, setupCfnDistro } from './cdk/utils/cfnDistro'
-import { SetupImageLambdaProps, setupImageLambda } from './cdk/utils/imageLambda'
-import { SetupServerLambdaProps, setupServerLambda } from './cdk/utils/serverLambda'
-import { UploadAssetsProps, setupAssetsBucket, uploadStaticAssets } from './cdk/utils/s3'
-import { SetupDnsRecordsProps, setupDnsRecords, prepareDomains, PrepareDomainProps } from './cdk/utils/dnsRecords'
+export { handler as serverHandler } from './server-handler'
 
 export const CdkUtils = {
 	setupApiGateway,
@@ -24,13 +23,12 @@ export const CdkUtils = {
 }
 
 export {
-	//
+	PrepareDomainProps,
 	SetupApiGwProps,
-	SetupCfnDistroProps,
 	SetupCfnCertificateProps,
+	SetupCfnDistroProps,
+	SetupDnsRecordsProps,
 	SetupImageLambdaProps,
 	SetupServerLambdaProps,
 	UploadAssetsProps,
-	SetupDnsRecordsProps,
-	PrepareDomainProps,
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -89,7 +89,7 @@ export const executeAsyncCmd = async ({ cmd, path, env }: CommandProps) => {
 
 	return new Promise((resolve, reject) => {
 		console.log('Executing command: ', cmd)
-		const sh = exec(cmd, { env: { ...process.env, ...env } }, (error, stdout, stderr) => {
+		const sh = exec(cmd, { env: { ...process.env, ...env } }, (error, stdout) => {
 			if (error) {
 				reject(error)
 			} else {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "dist"
   ],
   "scripts": {
-    "lint:check": "eslint ./lib/**/*.ts",
-    "lint:fix": "eslint --fix ./lib/**/*.ts",
+    "lint:check": "eslint ./lib/** --ext .ts",
+    "lint:fix": "eslint --fix ./lib/** --ext .ts",
     "prebuild": "rm -rf dist",
     "build": "npm run build:cli && npm run build:main && npm run build:cdk && npm run build:handler",
     "build:cdk": "tsup lib/cdk/app.ts --out-dir dist/cdk",


### PR DESCRIPTION
I've forked the repo recently.  During my journey through the codebaseI I noticed that your current eslint scripts applies only to files placed directly in the lib folder and other deeper nested files are not included. It bothered me to see so many red underlines in the editor so I kindly dared to create this PR.

### The PR fixed following:
- eslint import errors in all files TS files in lib folder
- two eslint unused var errors
- eslint scripts now cover all the lib TS files

There still remains one warning regarding the format code which is for some reason not fixed by prettier. We can just ignore this for now or add eslint-ignore comment.